### PR TITLE
Cleanup + Show args in switchOnEngineThenDrive

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The statement:
 
 ```javascript
-const doubleThenSquareThenHalf = value=>half(square(double(value)))
+const doubleThenSquareThenHalf = value => half(square(double(value)))
 ```
 
 would be rewritable as:
@@ -21,7 +21,7 @@ const doubleThenSquareThenHalfAsync = double +> squareAsync +> half
 It would be usable to tersely express the following:
 
 ```javascript
-const switchOnEngineThenDrive = ()=>{switchOnEngine(); drive()}
+const switchOnEngineThenDrive = driver => drive(switchOnEngine(driver))
 ```
 
 as:


### PR DESCRIPTION
Just cleaned some things up with extra spacing in the arrow functions + tried to better show the composition in `switchOnEngineThenDrive` by showing how its arguments would get passed through.